### PR TITLE
Ticket #7 - User can add a payment type

### DIFF
--- a/ecomm/forms/__init__.py
+++ b/ecomm/forms/__init__.py
@@ -1,1 +1,1 @@
-from .forms import UserForm, ProductForm
+from .forms import UserForm, ProductForm, AddPayment

--- a/ecomm/forms/forms.py
+++ b/ecomm/forms/forms.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 from django import forms
-from ecomm.models import Product, Customer
+from ecomm.models import Product, Customer, PaymentType
 
 # class EditSettings(forms.Form):
 #   lastName = forms.CharField(label='lastName', max_length=20)
@@ -20,6 +20,8 @@ class ProductForm(forms.ModelForm):
         model = Product
         fields = ('title', 'productType', 'description', 'price', 'quantity', 'location',)
 
-# class SearchForm(forms.ModelForm)
+class AddPayment(forms.ModelForm):
 
-#     class
+    class Meta:
+        model = PaymentType
+        fields = ('name', 'cardNum',)

--- a/ecomm/templates/ecomm/addPayment.html
+++ b/ecomm/templates/ecomm/addPayment.html
@@ -1,0 +1,7 @@
+<h1>Add New Payment</h1>
+{% include "ecomm/navbar.html" %}
+
+<form action="{% url 'ecomm:addPayment' %}" method="POST">
+
+
+</form>

--- a/ecomm/templates/ecomm/addPayment.html
+++ b/ecomm/templates/ecomm/addPayment.html
@@ -2,6 +2,7 @@
 {% include "ecomm/navbar.html" %}
 
 <form action="{% url 'ecomm:addPayment' %}" method="POST">
-
-
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Add" />
 </form>

--- a/ecomm/templates/ecomm/editPayments.html
+++ b/ecomm/templates/ecomm/editPayments.html
@@ -7,3 +7,5 @@
         {% csrf_token %}
         <input type="submit" value="X" /></form></p>
 {%endfor%}
+<br>
+<a href="{% url 'ecomm:addPaymentsForm' %}"><button>Add New Payment Option</button></a>

--- a/ecomm/templates/ecomm/userSettings.html
+++ b/ecomm/templates/ecomm/userSettings.html
@@ -14,7 +14,7 @@
     {%for payment in payments%}
 <p>{{payment.name}} {{payment.cardNum}}</p>
     {%endfor%}
-    <a href="{% url 'ecomm:editPaymentsForm' %}"><button>Update Payment Options</button></a>
+    <a href="{% url 'ecomm:editPaymentsForm' %}"><button>Add/Delete Payment Options</button></a>
     <br>
 <h3>Order History:</h3>
     {%for item in history%}

--- a/ecomm/urls.py
+++ b/ecomm/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path('userSettings', views.userSettings, name='userSettings'),
     path('editPaymentsForm', views.editPaymentsForm, name='editPaymentsForm'),
     path('addPaymentsForm', views.addPaymentsForm, name='addPaymentsForm'),
+    path('addPayment', views.addPayment, name='addPayment'),
     path('deletePayment/<int:payment_id>/', views.deletePayment, name='deletePayment'),
     path('editSettingsForm', views.editSettingsForm, name='editSettingsForm'),
     path('products/<int:product_id>/', views.productDetail, name='productDetail'),

--- a/ecomm/urls.py
+++ b/ecomm/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path('products/<int:product_id>/', views.productDetail, name='productDetail'),
     path('userSettings', views.userSettings, name='userSettings'),
     path('editPaymentsForm', views.editPaymentsForm, name='editPaymentsForm'),
+    path('addPaymentsForm', views.addPaymentsForm, name='addPaymentsForm'),
     path('deletePayment/<int:payment_id>/', views.deletePayment, name='deletePayment'),
     path('editSettingsForm', views.editSettingsForm, name='editSettingsForm'),
     path('products/<int:product_id>/', views.productDetail, name='productDetail'),

--- a/ecomm/views/__init__.py
+++ b/ecomm/views/__init__.py
@@ -8,4 +8,5 @@ from .sellProduct import sell_product
 from .editSettings import editSettings
 from .editSettings import editSettingsForm
 from .editSettings import editPaymentsForm
+from .editSettings import addPaymentsForm
 from .editSettings import deletePayment

--- a/ecomm/views/__init__.py
+++ b/ecomm/views/__init__.py
@@ -9,4 +9,5 @@ from .editSettings import editSettings
 from .editSettings import editSettingsForm
 from .editSettings import editPaymentsForm
 from .editSettings import addPaymentsForm
+from .editSettings import addPayment
 from .editSettings import deletePayment

--- a/ecomm/views/editSettings.py
+++ b/ecomm/views/editSettings.py
@@ -95,15 +95,32 @@ def deletePayment(request, payment_id):
     return HttpResponseRedirect(reverse('ecomm:editPaymentsForm'))
 
 def addPaymentsForm(request):
+    """R Lancaster[directs the user to the Add Payment template]
+
+    Arguments:
+        request
+
+    Returns:
+        render
+    """
+
     form = AddPayment()
     return render(request, 'ecomm/addPayment.html', {"form" : form})
 
 def addPayment(request):
+    """R Lancaster[method takes values entered on Add Payment form and inserts a row into the PaymentType table]
+
+    Arguments:
+        request
+
+    Returns:
+        redirects user to the Edit Payments Form page
+    """
+
     currentUserId = request.user.id
     name = request.POST['name']
     cardNum = request.POST['cardNum']
-
-    # Creates a new customer row using the id of the user that was just created for the customer primary key and the user foreign key
+    # Creates a new payment type row
     payment_sql = ''' INSERT INTO ecomm_paymenttype VALUES (%s, %s, %s, %s, %s)'''
     with connection.cursor() as cursor:
         cursor.execute(payment_sql, [None, name, cardNum, '', currentUserId])

--- a/ecomm/views/editSettings.py
+++ b/ecomm/views/editSettings.py
@@ -6,6 +6,8 @@ from django.contrib.auth.models import User
 from ..models import Customer, ProductType, Product, ProductOrder, PaymentType, Order
 from django.utils import timezone
 from datetime import datetime, timedelta
+from ecomm.forms import AddPayment
+from django.db import connection
 # from ..forms import UserSettings
 
 @login_required
@@ -90,4 +92,19 @@ def deletePayment(request, payment_id):
         ''', [payment_id])[0]
     payment.deletedOn = formattedDate
     payment.save()
+    return HttpResponseRedirect(reverse('ecomm:editPaymentsForm'))
+
+def addPaymentsForm(request):
+    form = AddPayment()
+    return render(request, 'ecomm/addPayment.html', {"form" : form})
+
+def addPayment(request):
+    currentUserId = request.user.id
+    name = request.POST['name']
+    cardNum = request.POST['cardNum']
+
+    # Creates a new customer row using the id of the user that was just created for the customer primary key and the user foreign key
+    payment_sql = ''' INSERT INTO ecomm_paymenttype VALUES (%s, %s, %s, %s, %s)'''
+    with connection.cursor() as cursor:
+        cursor.execute(payment_sql, [None, name, cardNum, '', currentUserId])
     return HttpResponseRedirect(reverse('ecomm:editPaymentsForm'))


### PR DESCRIPTION
Description: From the payment options screen, there is now a button to add a new payment option.  Clicking the button routes the user to the form to enter payment option details. Saving routes the user back to the payment options screen.  Added new URL routes, methods and form to insert a new row into the PaymentType table.

Directions to test:
From the User Settings view, click the Add/Delete payment option button.  Then from the Payment Options view, click the Add New Payment Option button.  Fill out the name and card number, then save.  You should see the new payment option on the Payment Option screen as well as the main User Settings screen.

Link:
[https://github.com/blathering-barnacles/Bangazon-2/issues/7](url)